### PR TITLE
Register ownership

### DIFF
--- a/src/ProxyOwnerRegistry.sol
+++ b/src/ProxyOwnerRegistry.sol
@@ -17,7 +17,7 @@
 pragma solidity ^0.6.12;
 
 contract ProxyOwnerRegistry {
-    address owner;
+    address public owner;
     mapping (address => address) public registry;
 
     modifier auth() {

--- a/src/proxy.sol
+++ b/src/proxy.sol
@@ -101,7 +101,7 @@ contract ProxyFactory {
         emit SetRegistry(registry_);
     }
 
-    function build() public returns (address payable proxy) {
+    function build() external returns (address payable proxy) {
         proxy = address(new Proxy());
         address proxyOwner = registry.getOwner(proxy);
         Proxy(proxy).setOwner(proxyOwner);

--- a/src/proxy.t.sol
+++ b/src/proxy.t.sol
@@ -74,6 +74,7 @@ contract ProxyTest is DSTest {
         factory = new ProxyFactory();
         registry = new ProxyOwnerRegistry();
         assertEq(factory.owner(), address(this));
+        assertEq(registry.owner(), address(this));
         factory.setRegistry(address(registry));
         proxy = Proxy(factory.build());
     }


### PR DESCRIPTION
Add a proxy ownership registry that can be used when creating Proxies to set ownership at the time of creation.

This would allow the Bridge or a contract controlled by a keeper to be setup as the owner of the Registry and to register proxy owners based on data from Mainnet ultimately letting this be used as a bridge for people who need to claim their proxies on the L2