### PR TITLE
Add `test_Addresses_Nonce`

### DIFF
--- a/src/proxy.t.sol
+++ b/src/proxy.t.sol
@@ -330,7 +330,7 @@ contract AddressesTest is DSTest {
             nonce = i;
             if (address(factory) == 0xA26e15C895EFc0616177B7c1e7270A4C7D51C997) break;
         }
-        assertTrue(nonce == 234, "non-matching-factory-nonce");
+        assertEq(nonce, 234, "non-matching-factory-nonce");
         assertEq(address(factory), factory_nonce, "non-match-factory-nonce-addr");
         assertEq(address(factory), 0xA26e15C895EFc0616177B7c1e7270A4C7D51C997, "non-matching-factory");
         assertEq(factory.owner(), address(this), "non-matching-owner");

--- a/src/proxy.t.sol
+++ b/src/proxy.t.sol
@@ -331,9 +331,9 @@ contract AddressesTest is DSTest {
             if (address(factory) == 0xA26e15C895EFc0616177B7c1e7270A4C7D51C997) break;
         }
         assertEq(nonce, 234, "non-matching-factory-nonce");
-        assertEq(address(factory), factory_nonce, "non-match-factory-nonce-addr");
-        assertEq(address(factory), 0xA26e15C895EFc0616177B7c1e7270A4C7D51C997, "non-matching-factory");
-        assertEq(factory.owner(), address(this), "non-matching-owner");
+        assertEq(address(factory), factory_nonce, "non-matching-factory-nonce-addr");
+        assertEq(address(factory), 0xA26e15C895EFc0616177B7c1e7270A4C7D51C997, "non-matching-factory-addr");
+        assertEq(factory.owner(), address(this), "non-matching-owner-addr");
 
         for (uint256 i = 1; i <= type(uint256).max; i++) {
             proxy = factory.build();
@@ -344,6 +344,6 @@ contract AddressesTest is DSTest {
         assertEq(nonce, 7400, "non-matchig-proxy-nonce");
         assertEq(proxy, proxy_nonce, "non-matching-proxy-nonce-addr");
         assertEq(proxy, 0x1CC7e8e35e67a3227f30F8caA001Ee896D0749eE, "non-matching-proxy-addr");
-        assertEq(Proxy(proxy).owner(), factory.owner(), "proxy-owner-non-matching-factory-owner");
+        assertEq(Proxy(proxy).owner(), factory.owner(), "proxy-owner-non-matching-factory-owner-addr");
     }
 }

--- a/src/proxy.t.sol
+++ b/src/proxy.t.sol
@@ -326,7 +326,7 @@ contract AddressesTest is DSTest {
         if(_nonce <= 0xff)     return address(uint160(uint256(keccak256(abi.encodePacked(byte(0xd7), byte(0x94), _origin, byte(0x81), uint8(_nonce))))));
         if(_nonce <= 0xffff)   return address(uint160(uint256(keccak256(abi.encodePacked(byte(0xd8), byte(0x94), _origin, byte(0x82), uint16(_nonce))))));
         if(_nonce <= 0xffffff) return address(uint160(uint256(keccak256(abi.encodePacked(byte(0xd9), byte(0x94), _origin, byte(0x83), uint24(_nonce))))));
-        return address(uint160(uint256(keccak256(abi.encodePacked(byte(0xda), byte(0x94), _origin, byte(0x84), uint32(_nonce)))))); // more than 2^32 nonces not realistic
+        return address(uint160(uint256(keccak256(abi.encodePacked(byte(0xda), byte(0x94), _origin, byte(0x84), uint32(_nonce)))))); // up to 2^32 nonces
     }
     function test_Addresses_Nonce() public {
         assertEq(address(this), 0xdB33dFD3D61308C33C63209845DaD3e6bfb2c674, "non-matching-from-addr");

--- a/src/proxy.t.sol
+++ b/src/proxy.t.sol
@@ -295,7 +295,7 @@ contract User {
 
 contract AddressesTest is DSTest {
     ProxyFactory factory;
-    address payable proxy;
+    address proxy;
 
     // --- Nonce Trick ---
     address factory_nonce;
@@ -372,7 +372,7 @@ contract AddressesTest is DSTest {
         assertEq(nonce, 7400, "non-matchig-proxy-target-nonce");
         assertEq(proxy, proxy_nonce, "non-matching-proxy-nonce-target-addr");
         assertEq(proxy, 0x1CC7e8e35e67a3227f30F8caA001Ee896D0749eE, "non-matching-proxy-addr");
-        assertEq(Proxy(proxy).owner(), factory.owner(), "proxy-owner-non-matching-factory-owner-addr");
+        assertEq(Proxy(payable(proxy)).owner(), factory.owner(), "proxy-owner-non-matching-factory-owner-addr");
     }
 
     function test_recoverFunds() public {

--- a/src/proxy.t.sol
+++ b/src/proxy.t.sol
@@ -349,7 +349,7 @@ contract AddressesTest is DSTest {
     function test_Addresses_Nonce() public {
         assertEq(address(this), 0xdB33dFD3D61308C33C63209845DaD3e6bfb2c674, "non-matching-from-addr");
 
-        // the deployer in tests is a contract so nonces start from 1
+        // the deployer in tests is a contract instead of a EOA so nonces start from 1 instead of 0
         for(uint256 i = 1; i <= type(uint256).max; i++) {
             factory = new ProxyFactory();
             factory_nonce = addrFromNonce(address(this), i);
@@ -374,7 +374,7 @@ contract AddressesTest is DSTest {
         assertEq(proxy, 0x1CC7e8e35e67a3227f30F8caA001Ee896D0749eE, "non-matching-proxy-addr");
         assertEq(Proxy(proxy).owner(), factory.owner(), "proxy-owner-non-matching-factory-owner-addr");
     }
-    
+
     function test_recoverFunds() public {
         payable(0x1CC7e8e35e67a3227f30F8caA001Ee896D0749eE).transfer(1 ether);
         assertEq(address(0x1CC7e8e35e67a3227f30F8caA001Ee896D0749eE).balance, 1 ether);


### PR DESCRIPTION
Add `test_Addresses_Nonce` to compute ProxyFactory and Proxy addresses deterministically by hashing the sender address and nonces.